### PR TITLE
Fixes incorrect @internal markings which makes consumer builds fail.

### DIFF
--- a/src/derivable/atom.ts
+++ b/src/derivable/atom.ts
@@ -15,13 +15,6 @@ export class Atom<V> extends Derivable<V> {
 
     /**
      * @internal
-     * Contains the current value of this atom. Note that this field is public for transaction support, should
-     * not be used in application code. Use {@link Derivable#get} and {@link Atom#set} instead.
-     */
-    public value: V;
-
-    /**
-     * @internal
      * Construct a new atom with the provided initial value.
      *
      * @param value the initial value
@@ -31,6 +24,13 @@ export class Atom<V> extends Derivable<V> {
         this.value = value;
         logger.trace({ id: this.id, value }, 'created');
     }
+
+    /**
+     * @internal
+     * Contains the current value of this atom. Note that this field is public for transaction support, should
+     * not be used in application code. Use {@link Derivable#get} and {@link Atom#set} instead.
+     */
+    value: V;
 
     /**
      * @internal

--- a/src/derivable/atom.ts
+++ b/src/derivable/atom.ts
@@ -12,20 +12,23 @@ const logger = Logger.get('@politie/sherlock.atom');
  * with the initial state.
  */
 export class Atom<V> extends Derivable<V> {
+
     /**
+     * @internal
+     * Contains the current value of this atom. Note that this field is public for transaction support, should
+     * not be used in application code. Use {@link Derivable#get} and {@link Atom#set} instead.
+     */
+    public value: V;
+
+    /**
+     * @internal
      * Construct a new atom with the provided initial value.
      *
      * @param value the initial value
      */
-    constructor(
-        /**
-         * @internal
-         * Contains the current value of this atom. Note that this field is public for transaction support, should
-         * not be used in application code. Use {@link Derivable#get} and {@link Atom#set} instead.
-         */
-        public value: V,
-    ) {
+    constructor(value: V) {
         super();
+        this.value = value;
         logger.trace({ id: this.id, value }, 'created');
     }
 

--- a/src/derivable/derivation.ts
+++ b/src/derivable/derivation.ts
@@ -193,6 +193,7 @@ export class Derivation<V> extends Derivable<V> implements TrackedObserver {
     }
 
     /**
+     * @internal
      * Mark this derivation and all observers of this derivation as "possible outdated" or "state unknown". If this derivation is already
      * in that state, all observers of this derivation are also expected to already be in that state. This invariant should never
      * be invalidated. Any reactors we encounter are pushed into the reactorSink.

--- a/src/reactor/reactor.ts
+++ b/src/reactor/reactor.ts
@@ -169,6 +169,7 @@ export class Reactor<V> implements Observer {
     }
 
     /**
+     * @internal
      * During the mark phase add this reactor to the reactorSink. This way, the transaction knows we exist and we get to `reactIfNeeded`
      * later on.
      */

--- a/src/tracking/tracking.ts
+++ b/src/tracking/tracking.ts
@@ -127,21 +127,26 @@ export function recordObservation(dependency: TrackedObservable) {
 
 export interface Observable {
     readonly id: number;
+    /** @internal */
     version: number;
 }
 
 export interface TrackedObservable extends Observable {
+    /** @internal */
     readonly observers: Observer[];
 }
 
 export interface Observer {
+    /** @internal */
     disconnect(): void;
     mark(reactorSink: Reactor[]): void;
 }
 
 export interface TrackedObserver extends Observer {
     readonly id: number;
+    /** @internal */
     readonly dependencies: TrackedObservable[];
+    /** @internal */
     readonly dependencyVersions: { [id: number]: number };
 }
 

--- a/src/tracking/tracking.ts
+++ b/src/tracking/tracking.ts
@@ -139,6 +139,7 @@ export interface TrackedObservable extends Observable {
 export interface Observer {
     /** @internal */
     disconnect(): void;
+    /** @internal */
     mark(reactorSink: Reactor[]): void;
 }
 


### PR DESCRIPTION
Some interface and class properties were not marked `@internal`, which made the resulting library `*.d.ts` files have incorrect typings.

Closes [#20](https://github.com/politie/sherlock/issues/20).