### PR TITLE
Extends ProxyDescriptor with a $path property.

### DIFF
--- a/extensions/sherlock-proxy/index.ts
+++ b/extensions/sherlock-proxy/index.ts
@@ -1,3 +1,3 @@
 export {
-    DerivableProxy, extendExpression, isDerivableProxy, MaybePacked, ProxyDescriptor, unpackProxy,
+    DerivableProxy, extendExpression, extendPath, isDerivableProxy, MaybePacked, ProxyDescriptor, unpackProxy,
 } from './proxy';

--- a/extensions/sherlock-proxy/proxy.spec.ts
+++ b/extensions/sherlock-proxy/proxy.spec.ts
@@ -58,6 +58,16 @@ typeof Proxy !== 'undefined' && describe('proxy', () => {
                 expect(obj.prop.$pluck(1).$expression).to.equal('.prop[1]');
             });
 
+            it('should expose the extended path when plucked', () => {
+                const obj = createForObject({}) as any;
+                expect(obj.$path).to.be.undefined;
+                expect(obj.prop1.$path).to.deep.equal(['prop1']);
+                expect(obj.prop1.prop2.$path).to.deep.equal(['prop1', 'prop2']);
+                expect(obj.prop1[0][1][2].$path).to.deep.equal(['prop1', '0', '1', '2']);
+
+                expect(obj.prop.$pluck(2).$path).to.deep.equal(['prop', 2]);
+            });
+
             it('should be possible to override the default $pluck behavior', () => {
                 const pd = new ProxyDescriptor<string>();
                 pd.$pluck = function (this: ProxyDescriptor<string>, prop: string | number) {

--- a/extensions/sherlock-proxy/proxy.ts
+++ b/extensions/sherlock-proxy/proxy.ts
@@ -12,13 +12,13 @@ export interface DerivableProxy<V> {
     $value: V;
 
     /** A string representation of this proxy's path from the root ProxyDescriptor. */
-    $expression: string;
+    $expression?: string;
 
     /**
      * An array representation of this proxy's path from the root ProxyDescriptor. Useful for programatically walking down the root
      * Descriptor's object tree to reacquire a target proxy.
      */
-    $path: Array<string | number>;
+    $path?: Array<string | number>;
 
     /** {@see Derivable#and} */
     $and<W>(other: MaybePacked<W>): Derivable<V | W>;
@@ -362,6 +362,5 @@ export function extendExpression(expression = '', property: string | number) {
  * @param property the property that should be appended to the path
  */
 export function extendPath(path: Array<string | number> = [], property: string | number) {
-    path.push(property);
-    return path;
+    return path.concat(property);
 }

--- a/extensions/sherlock-proxy/proxy.ts
+++ b/extensions/sherlock-proxy/proxy.ts
@@ -11,8 +11,14 @@ export interface DerivableProxy<V> {
     /** The current value that this Proxy represents. Can be expensive to calculate and is often writable. */
     $value: V;
 
-    /** The path for this proxy's {@link DerivableProxy#$value} through the proxy object model. */
+    /** A string representation of this proxy's path from the root ProxyDescriptor. */
     $expression: string;
+
+    /**
+     * An array representation of this proxy's path from the root ProxyDescriptor. Useful for programatically walking down the root
+     * Descriptor's object tree to reacquire a target proxy.
+     */
+    $path: Array<string | number>;
 
     /** {@see Derivable#and} */
     $and<W>(other: MaybePacked<W>): Derivable<V | W>;


### PR DESCRIPTION
While `$expression` produces a nice string representation to a `DerivableProxy`'s location in the original `ProxyDescriptor` hierarchy, it's a bit cumbersome to unpack and interpret that string when one wants to programatically walk down that path again.

This PR adds a `$path` property to any `ProxyDescriptor`. It is an array of strings and numbers and can be used to reduce some (root) `DerivableProxy` to a desired target with a given `$path` array, like so:

```typescript
/**
 * Suppose we only have the original Proxy and a path, i.e. from a window.postMessage communication.
 * This function will walk down the original Proxy's object model to find the target at `path`.
 */
function findTargetFromPath(path: Array<string | number>, originalProxy: DerivableProxy<any>) {
    return path.reduce((accumulator: DerivableProxy<any>, next: string | number) => accumulator[next], originalProxy);
}
```