### PR TITLE
Fixed bug for cyclical reactors with `once: true`

### DIFF
--- a/src/reactor/reactor.spec.ts
+++ b/src/reactor/reactor.spec.ts
@@ -403,6 +403,17 @@ describe('reactor/reactor', () => {
         shouldNotHaveReacted();
     });
 
+    it('should never react twice when `once` is `true`', () => {
+        currentReactorTest = { reactions: 0, value: undefined };
+        a$.react(v => {
+            currentReactorTest!.reactions++;
+            currentReactorTest!.value = v;
+            a$.set(v + '!');
+        }, { once: true });
+
+        shouldHaveReactedOnce('a');
+    });
+
     it('should support combining `skipFirst` and `once`, skipping 1 and taking 1', () => {
         react(a$, { skipFirst: true, once: true });
 

--- a/src/reactor/reactor.ts
+++ b/src/reactor/reactor.ts
@@ -222,11 +222,12 @@ export class Reactor<V> implements Observer {
         const reactor = new Reactor<W>(parent, errorHandler, value => {
             if (skipFirst) {
                 skipFirst = false;
+            } else if (once) {
+                stopReactors();
+                reaction(value);
+                ended && ended();
             } else {
                 reaction(value);
-                if (once) {
-                    done();
-                }
             }
         });
 
@@ -257,10 +258,14 @@ export class Reactor<V> implements Observer {
                 }
             });
 
-        function done() {
+        function stopReactors() {
             starter && starter._stop();
             controller && controller._stop();
             reactor._stop();
+        }
+
+        function done() {
+            stopReactors();
             ended && ended();
         }
 


### PR DESCRIPTION
I am very sorry, @njirem, you already fixed this bug earlier. Forgot to include the fix.