### PR TITLE
Exports toObservable as an independent function

### DIFF
--- a/extensions/sherlock-rxjs/rxjs.spec.ts
+++ b/extensions/sherlock-rxjs/rxjs.spec.ts
@@ -1,10 +1,10 @@
 import { _internal, atom, SettableDerivable } from '@politie/sherlock';
 import { expect } from 'chai';
 import { Subject } from 'rxjs';
-import { fromObservable } from './rxjs';
+import { fromObservable, toObservable } from './rxjs';
 
 describe('rxjs/rxjs', () => {
-    describe('Derivable#toObservable', () => {
+    describe('toObservable', () => {
         let a$: SettableDerivable<string>;
 
         beforeEach('create the atom', () => { a$ = atom('a'); });
@@ -12,7 +12,7 @@ describe('rxjs/rxjs', () => {
         it('should complete the Observable when until becomes true', () => {
             let complete = false;
             let value = '';
-            a$.toObservable({ until: d$ => d$.get().length > 2 }).subscribe(v => value = v, undefined, () => complete = true);
+            toObservable(a$, { until: d$ => d$.get().length > 2 }).subscribe(v => value = v, undefined, () => complete = true);
             expect(complete).to.be.false;
             expect(value).to.equal('a');
 
@@ -28,7 +28,7 @@ describe('rxjs/rxjs', () => {
         it('should complete the Observable after one value when once is true', () => {
             let complete = false;
             const values: string[] = [];
-            a$.toObservable({ once: true }).subscribe(v => values.push(v), undefined, () => complete = true);
+            toObservable(a$, { once: true }).subscribe(v => values.push(v), undefined, () => complete = true);
             expect(complete).to.be.true;
             expect(values).to.deep.equal(['a']);
 
@@ -39,7 +39,7 @@ describe('rxjs/rxjs', () => {
         it('should skip the first value if skipFirst is true', () => {
             let complete = false;
             const values: string[] = [];
-            a$.toObservable({ skipFirst: true, once: true }).subscribe(v => values.push(v), undefined, () => complete = true);
+            toObservable(a$, { skipFirst: true, once: true }).subscribe(v => values.push(v), undefined, () => complete = true);
             expect(complete).to.be.false;
             expect(values).to.be.empty;
 
@@ -53,7 +53,7 @@ describe('rxjs/rxjs', () => {
         });
 
         it('should stop the internal reactor when the Observable is unobserved', () => {
-            const sub = a$.toObservable().subscribe();
+            const sub = toObservable(a$).subscribe();
             expect(a$[_internal.symbols.observers]).not.to.be.empty;
             sub.unsubscribe();
             expect(a$[_internal.symbols.observers]).to.be.empty;
@@ -62,7 +62,7 @@ describe('rxjs/rxjs', () => {
         it('should support multiple subscriptions to the returned Observable', () => {
             const values1: string[] = [];
             const values2: string[] = [];
-            const obs = a$.toObservable();
+            const obs = toObservable(a$);
             const sub1 = obs.subscribe(v => values1.push(v));
             const sub2 = obs.subscribe(v => values2.push(v));
 
@@ -86,7 +86,7 @@ describe('rxjs/rxjs', () => {
 
         it('should not complete on unsubscribe', () => {
             let complete = false;
-            a$.toObservable().subscribe(undefined, undefined, () => complete = true).unsubscribe();
+            toObservable(a$).subscribe(undefined, undefined, () => complete = true).unsubscribe();
             expect(complete).to.be.false;
         });
     });

--- a/extensions/sherlock-rxjs/rxjs.ts
+++ b/extensions/sherlock-rxjs/rxjs.ts
@@ -1,34 +1,21 @@
 import { _internal, atom, Derivable, ReactorOptions } from '@politie/sherlock';
 import { Observable, Subscriber, Subscription } from 'rxjs';
 
-// Adds the toObservable method to Derivable.
-declare module '@politie/sherlock/derivable/extension' {
-    export interface DerivableExtension<V> {
-        /**
-         * Create an RxJS Observable from this Derivable. The Observable stream can be tweaked with the same options that
-         * can also be used with {@link Derivable#react}.
-         *
-         * @param options optional options that indicate how to transform the Derivable into an Observable stream
-         */
-        toObservable(options?: Partial<ReactorOptions<V>>): Observable<V>;
-    }
-}
-
-_internal.BaseDerivable.prototype.toObservable = function toObservable<V>(
-    this: _internal.BaseDerivable<V>,
-    options?: Partial<ReactorOptions<V>>,
-) {
+/**
+ * Creates an RxJS Observable from a Derivable. Optionally accepts a `ReactorOptions` that governs RxJS emissions
+ * and lifecycle equivalent to {@link Derivable#react} {@link ReactorOptions}.
+ * @param derivable Derivable to create an RxJS Observable from.
+ * @param options Partial `ReactorOptions`.
+ */
+export function toObservable<V>(derivable: Derivable<V>, options?: Partial<ReactorOptions<V>>): Observable<V> {
     return new Observable<V>((subscriber: Subscriber<V>) => {
-        return _internal.Reactor.create(this,
-            // onValue: notify subscriber
+        return _internal.Reactor.create(derivable as _internal.BaseDerivable<V>,
             value => subscriber.next(value),
-            // Merge the options with the default options.
             options,
-            // onComplete: notify subscriber unless explicitly unsubscribed
             () => subscriber.closed || subscriber.complete(),
         );
     });
-};
+}
 
 export function fromObservable<V>(observable: Observable<V>): Derivable<V> {
     const atom$ = atom.unresolved<V>();

--- a/scripts/process-bundle.js
+++ b/scripts/process-bundle.js
@@ -72,7 +72,7 @@ Module._resolveFilename = function (request, ...rest) {
 
 const sherlock = require('@politie/sherlock');
 const utils = require('@politie/sherlock-utils');
-require('@politie/sherlock-rxjs');
+const rxjs = require('@politie/sherlock-rxjs');
 
 const a$ = sherlock.atom({ nested: { property: 'value' } });
 
@@ -88,6 +88,6 @@ value$.set('another value');
 assert.deepStrictEqual(receivedValue, { nested: { property: 'another value' } });
 assert.deepStrictEqual(utils.getStateObject(value$), { value: 'another value', resolved: true, errored: false });
 
-assert.ok(a$.toObservable());
+assert.ok(rxjs.toObservable(a$));
 
 console.log('Bundles ok.');


### PR DESCRIPTION
The `Derivable` prototype is no longer monkey-patched with a `toObservable` method.  `toObservable` is now a function that accepts two arguments: the `Derivable` to turn into an `Observable` and optional `ReactorOptions`.