### PR TITLE
fixes support for Observables that complete synchronously

### DIFF
--- a/extensions/sherlock-rxjs/rxjs.test.ts
+++ b/extensions/sherlock-rxjs/rxjs.test.ts
@@ -1,5 +1,5 @@
 import { _internal, atom, DerivableAtom } from '@politie/sherlock';
-import { defer, Subject } from 'rxjs';
+import { defer, of, Subject } from 'rxjs';
 import { fromObservable, toObservable } from './rxjs';
 
 describe('rxjs/rxjs', () => {
@@ -356,6 +356,13 @@ describe('rxjs/rxjs', () => {
             } catch (e) {
                 expect(e.message).toBe('my error');
             }
+        });
+
+        it('should support scalar observables', () => {
+            const obs = of(1);
+            const d$ = fromObservable(obs);
+            expect(d$.value).toBe(undefined);
+            expect(d$.autoCache().value).toBe(1);
         });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@politie/sherlock",
-    "version": "3.0.0-beta.0",
+    "version": "3.0.0-beta.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@politie/sherlock",
-    "version": "3.0.0-beta.0",
+    "version": "3.0.0-beta.1",
     "private": true,
     "description": "A reactive programming library for JavaScript applications, built with TypeScript.",
     "main": "sherlock.cjs.js",


### PR DESCRIPTION
New sherlock-rxjs implementation errors on synchronous completion of Observables on subscription. This is fixed and tested in this PR.