### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # This is a public_repo Github personal access token.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
       - name: Bump version
         id: lib-bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,11 @@ jobs:
     if: ${{ !startsWith(github.event.head_commit.message, '[CI/CD]') }}
     outputs:
       tag-name: ${{ steps.lib-bump.outputs.newTag }}
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
+          # This is a public_repo Github personal access token.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump version


### PR DESCRIPTION
GITHUB_TOKEN cannot be used for bumping versions. To fix it the previous token (WORKFLOW_GITHUB_TOKEN) is used again