### PR TITLE
Update to latest RxJS version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "editor.codeActionsOnSave": {
         "source.fixAll": "explicit"
     },
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "npm.exclude": "**/dist/**"
 }

--- a/extensions/sherlock-rxjs/package.json
+++ b/extensions/sherlock-rxjs/package.json
@@ -39,6 +39,6 @@
     },
     "peerDependencies": {
         "@politie/sherlock": "0.0.0-PLACEHOLDER",
-        "rxjs": "^5.4.0 || ^6.0.0"
+        "rxjs": "^5.4.0 || ^6.0.0 || ^7.0.0 "
     }
 }

--- a/extensions/sherlock-rxjs/rxjs.test.ts
+++ b/extensions/sherlock-rxjs/rxjs.test.ts
@@ -13,7 +13,10 @@ describe('rxjs/rxjs', () => {
             a$.setFinal('final value');
             let value = '';
             let complete = false;
-            toObservable(a$).subscribe(v => value = v, undefined, () => complete = true);
+            toObservable(a$).subscribe({
+                next: v => value = v,
+                complete: () => complete = true
+            });
             expect(value).toBe('final value');
             expect(complete).toBeTrue();
         });
@@ -21,7 +24,10 @@ describe('rxjs/rxjs', () => {
         it('should complete the Observable when the derivable becomes final', () => {
             let value = '';
             let complete = false;
-            toObservable(a$).subscribe(v => value = v, undefined, () => complete = true);
+            toObservable(a$).subscribe({
+                next: v => value = v,
+                complete:  () => complete = true
+            });
             expect(value).toBe('a');
             expect(complete).toBeFalse();
 
@@ -33,7 +39,10 @@ describe('rxjs/rxjs', () => {
         it('should complete the Observable when until becomes true', () => {
             let complete = false;
             let value = '';
-            toObservable(a$, { until: d$ => d$.get().length > 2 }).subscribe(v => value = v, undefined, () => complete = true);
+            toObservable(a$, { until: d$ => d$.get().length > 2 }).subscribe({
+                next: v => value = v,
+                complete: () => complete = true
+            });
             expect(complete).toBe(false);
             expect(value).toBe('a');
 
@@ -49,7 +58,10 @@ describe('rxjs/rxjs', () => {
         it('should complete the Observable after one value when once is true', () => {
             let complete = false;
             const values: string[] = [];
-            toObservable(a$, { once: true }).subscribe(v => values.push(v), undefined, () => complete = true);
+            toObservable(a$, { once: true }).subscribe({
+                next: v => values.push(v),
+                complete: () => complete = true
+            });
             expect(complete).toBe(true);
             expect(values).toEqual(['a']);
 
@@ -60,7 +72,10 @@ describe('rxjs/rxjs', () => {
         it('should skip the first value if skipFirst is true', () => {
             let complete = false;
             const values: string[] = [];
-            toObservable(a$, { skipFirst: true, once: true }).subscribe(v => values.push(v), undefined, () => complete = true);
+            toObservable(a$, { skipFirst: true, once: true }).subscribe({
+                next: v => values.push(v),
+                complete:  () => complete = true
+            });
             expect(complete).toBe(false);
             expect(Object.keys(values)).toHaveLength(0);
 
@@ -107,7 +122,7 @@ describe('rxjs/rxjs', () => {
 
         it('should not complete on unsubscribe', () => {
             let complete = false;
-            toObservable(a$).subscribe(undefined, undefined, () => complete = true).unsubscribe();
+            toObservable(a$).subscribe({ complete: () => complete = true}).unsubscribe();
             expect(complete).toBe(false);
         });
     });
@@ -115,7 +130,7 @@ describe('rxjs/rxjs', () => {
     describe('fromObservable', () => {
         it('should be unresolved until connected and the first value has been emitted', () => {
             const subj = new Subject<string>();
-            const d$ = fromObservable(subj);
+            const d$ = fromObservable<string>(subj);
 
             expect(d$.resolved).toBe(false);
             let value = '';
@@ -141,7 +156,7 @@ describe('rxjs/rxjs', () => {
 
         it('should subscribe to observable when used to power a reactor', () => {
             const subj = new Subject<string>();
-            const d$ = fromObservable(subj);
+            const d$ = fromObservable<string>(subj);
 
             expect(subj.observers).toHaveLength(0);
 
@@ -192,7 +207,7 @@ describe('rxjs/rxjs', () => {
         it('should disconnect and finalize when the observable completes', () => {
             const subj = new Subject<string>();
             let connections = 0;
-            const d$ = fromObservable(defer(() => (++connections, subj)));
+            const d$ = fromObservable<string>(defer(() => (++connections, subj)));
 
             expect(connections).toBe(0);
 
@@ -262,7 +277,7 @@ describe('rxjs/rxjs', () => {
 
         it('should disconnect when not directly used in a derivation', () => {
             const subj = new Subject<string>();
-            const obs$ = fromObservable(subj);
+            const obs$ = fromObservable<string>(subj);
             const useIt$ = atom(false);
             const derivation$ = useIt$.derive(v => v && obs$.get());
 
@@ -295,7 +310,7 @@ describe('rxjs/rxjs', () => {
         it('should work with a fallback when given and not connected', () => {
             const subj = new Subject<string>();
             const f$ = atom('fallback');
-            const d$ = fromObservable(subj).fallbackTo(f$);
+            const d$ = fromObservable<string>(subj).fallbackTo(f$);
             expect(d$.get()).toBe('fallback');
             expect(subj.observers).toHaveLength(0);
 

--- a/extensions/sherlock-rxjs/rxjs.test.ts
+++ b/extensions/sherlock-rxjs/rxjs.test.ts
@@ -130,7 +130,7 @@ describe('rxjs/rxjs', () => {
     describe('fromObservable', () => {
         it('should be unresolved until connected and the first value has been emitted', () => {
             const subj = new Subject<string>();
-            const d$ = fromObservable<string>(subj);
+            const d$ = fromObservable(subj);
 
             expect(d$.resolved).toBe(false);
             let value = '';
@@ -156,7 +156,7 @@ describe('rxjs/rxjs', () => {
 
         it('should subscribe to observable when used to power a reactor', () => {
             const subj = new Subject<string>();
-            const d$ = fromObservable<string>(subj);
+            const d$ = fromObservable(subj);
 
             expect(subj.observers).toHaveLength(0);
 
@@ -207,7 +207,7 @@ describe('rxjs/rxjs', () => {
         it('should disconnect and finalize when the observable completes', () => {
             const subj = new Subject<string>();
             let connections = 0;
-            const d$ = fromObservable<string>(defer(() => (++connections, subj)));
+            const d$ = fromObservable(defer(() => (++connections, subj)));
 
             expect(connections).toBe(0);
 
@@ -277,7 +277,7 @@ describe('rxjs/rxjs', () => {
 
         it('should disconnect when not directly used in a derivation', () => {
             const subj = new Subject<string>();
-            const obs$ = fromObservable<string>(subj);
+            const obs$ = fromObservable(subj);
             const useIt$ = atom(false);
             const derivation$ = useIt$.derive(v => v && obs$.get());
 
@@ -310,7 +310,7 @@ describe('rxjs/rxjs', () => {
         it('should work with a fallback when given and not connected', () => {
             const subj = new Subject<string>();
             const f$ = atom('fallback');
-            const d$ = fromObservable<string>(subj).fallbackTo(f$);
+            const d$ = fromObservable(subj).fallbackTo(f$);
             expect(d$.get()).toBe('fallback');
             expect(subj.observers).toHaveLength(0);
 

--- a/extensions/sherlock-rxjs/rxjs.ts
+++ b/extensions/sherlock-rxjs/rxjs.ts
@@ -1,5 +1,5 @@
 import { _internal, atom, Derivable, ErrorWrapper, ReactorOptions } from '@politie/sherlock';
-import { Observable, Subscriber, Unsubscribable } from 'rxjs';
+import { Observable, Subscriber, Subscription } from 'rxjs';
 
 /**
  * Creates an RxJS Observable from a Derivable. Optionally accepts a `ReactorOptions` that governs RxJS emissions
@@ -20,7 +20,7 @@ export function toObservable<V>(derivable: Derivable<V>, options?: Partial<React
 export function fromObservable<V>(observable: Observable<V>): Derivable<V> {
     const atom$ = atom.unresolved<V>();
 
-    let subscription: Unsubscribable | undefined;
+    let subscription: Subscription | undefined;
     atom$.connected$.react(() => {
         if (atom$.connected && !subscription) {
             subscription = observable.subscribe({

--- a/extensions/sherlock-rxjs/rxjs.ts
+++ b/extensions/sherlock-rxjs/rxjs.ts
@@ -23,11 +23,11 @@ export function fromObservable<V>(observable: Subscribable<V>): Derivable<V> {
     let subscription: Unsubscribable | undefined;
     atom$.connected$.react(() => {
         if (atom$.connected && !subscription) {
-            subscription = observable.subscribe(
-                value => atom$.set(value),
-                err => atom$.setFinal(new ErrorWrapper(err)),
-                () => atom$.setFinal(atom$.getState()),
-            );
+            subscription = observable.subscribe({
+                next: value => atom$.set(value),
+                error: err => atom$.setFinal(new ErrorWrapper(err)),
+                complete: () => atom$.setFinal(atom$.getState()),
+        });
         }
         // This is not chained with the previous as an `else` branch, because this can be true immediately after
         // the subscription occurs. Observables can complete synchronously on subscription.

--- a/extensions/sherlock-rxjs/rxjs.ts
+++ b/extensions/sherlock-rxjs/rxjs.ts
@@ -1,5 +1,5 @@
 import { _internal, atom, Derivable, ErrorWrapper, ReactorOptions } from '@politie/sherlock';
-import { Observable, Subscribable, Subscriber, Unsubscribable } from 'rxjs';
+import { Observable, Subscriber, Unsubscribable } from 'rxjs';
 
 /**
  * Creates an RxJS Observable from a Derivable. Optionally accepts a `ReactorOptions` that governs RxJS emissions
@@ -17,7 +17,7 @@ export function toObservable<V>(derivable: Derivable<V>, options?: Partial<React
     });
 }
 
-export function fromObservable<V>(observable: Subscribable<V>): Derivable<V> {
+export function fromObservable<V>(observable: Observable<V>): Derivable<V> {
     const atom$ = atom.unresolved<V>();
 
     let subscription: Unsubscribable | undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "rollup": "^2.50.5",
                 "rollup-plugin-sourcemaps": "^0.6.3",
                 "rollup-plugin-visualizer": "^5.5.0",
-                "rxjs": "^6.6.7",
+                "rxjs": "^7.8.1",
                 "shelljs": "^0.8.5",
                 "terser": "^5.14.2",
                 "ts-jest": "^27.0.2",
@@ -4868,22 +4868,13 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "6.6.7",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-            "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dev": true,
             "dependencies": {
-                "tslib": "^1.9.0"
-            },
-            "engines": {
-                "npm": ">=2.0.0"
+                "tslib": "^2.1.0"
             }
-        },
-        "node_modules/rxjs/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
@@ -9683,20 +9674,12 @@
             }
         },
         "rxjs": {
-            "version": "6.6.7",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-            "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dev": true,
             "requires": {
-                "tslib": "^1.9.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
-                }
+                "tslib": "^2.1.0"
             }
         },
         "safe-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,14 +1607,24 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001264",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
-            "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
+            "version": "1.0.30001600",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+            "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
             "dev": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
-            }
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ]
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -7211,9 +7221,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001264",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
-            "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
+            "version": "1.0.30001600",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+            "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
             "dev": true
         },
         "chalk": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "rollup": "^2.50.5",
         "rollup-plugin-sourcemaps": "^0.6.3",
         "rollup-plugin-visualizer": "^5.5.0",
-        "rxjs": "^6.6.7",
+        "rxjs": "^7.8.1",
         "shelljs": "^0.8.5",
         "terser": "^5.14.2",
         "ts-jest": "^27.0.2",

--- a/tutorial/6 - conversion.test.ts
+++ b/tutorial/6 - conversion.test.ts
@@ -133,7 +133,7 @@ describe.skip('conversion', () => {
         it('fromObservable', () => {
             let currentValue = 0;
             const subject$ = new Subject<number>();
-            const derivable$: Derivable<number> = fromObservable(subject$);
+            const derivable$ = fromObservable(subject$);
 
             derivable$.react((value => currentValue = value), { until: (value) => value.get() > 2 });
             expect(derivable$.resolved).toBe(false)

--- a/tutorial/6 - conversion.test.ts
+++ b/tutorial/6 - conversion.test.ts
@@ -133,7 +133,7 @@ describe.skip('conversion', () => {
         it('fromObservable', () => {
             let currentValue = 0;
             const subject$ = new Subject<number>();
-            const derivable$ = fromObservable(subject$);
+            const derivable$: Derivable<number> = fromObservable(subject$);
 
             derivable$.react((value => currentValue = value), { until: (value) => value.get() > 2 });
             expect(derivable$.resolved).toBe(false)


### PR DESCRIPTION
Updated RxJS to the latest version and updated some deprecated calls. Besides that the compiler was complaining about Type 'unknown' is not assignable to type 'string'. To fix this I added types (fromObservable<string>).

Notes:
- Call to subj.observers is deprecated and will be removed in v8. I propose to leave it in for now as there is no good alternative
- suppressImplicitAnyIndexErrors will be removed in Typescript 5.5. As this suppression is used a lot in the code I propose to leave it for now. There is a workaround to still allow the suppression ("ignoreDeprecations": "5.0")